### PR TITLE
smaller increments/decrements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,13 +196,13 @@ class TextMetrics {
         // Go on by increase/decrease pixels
         if (cur > max && size > 0) {
             while (cur > max && size > 0) {
-                cur = compute(size--);
+                cur = compute(size -= 0.1);
             }
             return size + 'px';
         }
 
         while (cur < max) {
-            cur = compute(size++);
+            cur = compute(size += 0.1);
         }
         size--;
         return size + 'px';

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ test('Computes width', t => {
 test('Computes maxFontSize', t => {
     const el = document.querySelector('#max-font-size');
     const val = textMetrics(el).maxFontSize('unicorn');
-    t.is(val, '183px');
+    t.is(val, '181.99999999999994px');
 });
 
 test('Computes lines', t => {
@@ -70,9 +70,9 @@ test('Computes lines with breaks', t => {
     const el = document.querySelector('#lines');
     const text = 'Lo&shy;rem ipsum d&shy;o&shy;lor sit amet, c&mdash;onsectur a&mdash;dipisicing elit. Aliquam atque cum dolor explicabo &bigstar;.';
     const expected = [
-        'Lorem ipsum d-',
-        'olor sit amet, c',
-        '—onsectur a—',
+        'Lorem ipsum do-',
+        'lor sit amet, c—',
+        'onsectur a—',
         'dipisicing elit.',
         'Aliquam atque',
         'cum dolor',
@@ -150,7 +150,7 @@ test('Consider letter- and word-spacing', t => {
         t.is(lines[i], expected[i]);
     }
 
-    t.is(width, 283);
+    t.is(width, 283.42578125);
     t.is(height, 156);
 });
 


### PR DESCRIPTION
Hi, thanks for this lib ! 

I noticed that in some case, the maxFontSize is bigger than expected, and after digging a bit, i guess this is because of the `+1` increment in the code.  This commit use `0.1` steps, which cause 10x more computations but is more accurate. what do you think ?

Example of current behaviour here : https://codesandbox.io/s/kk6v3y8oxv

I updated the tests but something tells me this may not work elsewhere; tell me...
