### PR TITLE
maxFontSize: add options.precision with default=1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Type: `object`
 
 | key       | default | description
 | --------- | ------- | -----------
-| multiline | `false`   | The width of widest line instead of the width of the complete text
+| multiline | `false` | The width of widest line instead of the width of the complete text
+| precision | 1.0     | Precision in px for the maxFontSize detection
 
 #### overwrites
 Type: `object`

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,8 @@ class TextMetrics {
             text = undefined;
         }
 
+        const precision = options.precision || 1.0;
+
         if (!text && this.el) {
             text = getText(this.el);
         } else {
@@ -196,13 +198,13 @@ class TextMetrics {
         // Go on by increase/decrease pixels
         if (cur > max && size > 0) {
             while (cur > max && size > 0) {
-                cur = compute(size--);
+                cur = compute(size -= precision);
             }
             return size + 'px';
         }
 
         while (cur < max) {
-            cur = compute(size++);
+            cur = compute(size += precision);
         }
         size--;
         return size + 'px';


### PR DESCRIPTION
replaces https://github.com/bezoerb/text-metrics/pull/1

i cant run the tests here : `[Error: Canvas support required]`